### PR TITLE
Add GUI launcher command with config environment support

### DIFF
--- a/sologit/cli/main.py
+++ b/sologit/cli/main.py
@@ -208,10 +208,8 @@ def gui(ctx, dev: bool):
 
     config_manager = ctx.obj.get('config') if ctx and ctx.obj else None
     env = os.environ.copy()
-    if config_manager is not None:
-        config_path = getattr(config_manager, "config_path", None)
-        if config_path:
-            env.setdefault("SOLOGIT_CONFIG_PATH", str(config_path))
+    if config_manager is not None and (config_path := getattr(config_manager, "config_path", None)):
+        env.setdefault("SOLOGIT_CONFIG_PATH", str(config_path))
 
     if dev:
         formatter.print_info("Launching GUI in development mode...")


### PR DESCRIPTION
## Summary
- update the `evogitctl gui` command to capture CLI context and forward the config path to the GUI process via environment variables
- ensure the GUI launcher shares the same environment in both dev and production modes while preserving existing error handling

## Testing
- python -m compileall sologit/cli/main.py

------
https://chatgpt.com/codex/tasks/task_e_68f815c2ce14832b9e3458311a5b6df3