### PR TITLE
Set subprocess default mode for test orchestrator

### DIFF
--- a/sologit/engines/test_orchestrator.py
+++ b/sologit/engines/test_orchestrator.py
@@ -87,7 +87,7 @@ class TestOrchestrator:
         self,
         git_engine: GitEngine,
         sandbox_image: str = "python:3.11-slim",
-        execution_mode: str = TestExecutionMode.AUTO.value,
+        execution_mode: str = TestExecutionMode.SUBPROCESS.value,
         log_dir: Optional[Path] = None,
         formatter: Optional[RichFormatter] = None,
     ) -> None:

--- a/tests/test_phase3_workflows.py
+++ b/tests/test_phase3_workflows.py
@@ -60,7 +60,6 @@ def test_workpad(git_engine, test_repo):
 
 class TestAutoMergeWorkflow:
     """Tests for AutoMergeWorkflow."""
-    __test__ = False
     
     def test_workflow_initialization(self, git_engine, test_orchestrator):
         """Test workflow can be initialized."""
@@ -110,7 +109,6 @@ class TestAutoMergeWorkflow:
 
 class TestCIOrchestrator:
     """Tests for CIOrchestrator."""
-    __test__ = False
     
     def test_orchestrator_initialization(self, git_engine, test_orchestrator):
         """Test CI orchestrator can be initialized."""


### PR DESCRIPTION
## Summary
- default the test orchestrator to subprocess execution to avoid unexpected Docker lookups
- allow pytest to collect phase 3 workflow tests by removing their __test__ overrides

## Testing
- pytest tests/test_phase3_workflows.py -v

------
https://chatgpt.com/codex/tasks/task_e_68f825be0b6c832b9f9bd497a6614ef9