### PR TITLE
Improve GUI launch handling

### DIFF
--- a/sologit/cli/main.py
+++ b/sologit/cli/main.py
@@ -246,7 +246,7 @@ def gui(ctx, dev: bool):
 
     formatter.print_info(f"Launching Heaven Interface GUI from {gui_path}...")
     try:
-        launch_cwd = gui_path.parent if gui_path.is_file() else gui_path
+        launch_cwd = gui_path.parent
         subprocess.Popen(
             [str(gui_path)],
             env=env,


### PR DESCRIPTION
## Summary
- ensure `evogitctl gui` starts the built binary from its directory for consistent resource loading
- detach the GUI process so the CLI exits cleanly after launching the application

## Testing
- not run (CLI change only)


------
https://chatgpt.com/codex/tasks/task_e_68f84c2f3340832ba3246377fb554b42