### PR TITLE
Fix: Resolve GUI build failures on Linux

### DIFF
--- a/heaven-gui/BUILDING.md
+++ b/heaven-gui/BUILDING.md
@@ -41,7 +41,7 @@ xcode-select --install
 
 ```bash
 sudo apt update
-sudo apt install libwebkit2gtk-4.0-dev \
+sudo apt install libwebkit2gtk-4.1-dev \
     build-essential \
     curl \
     wget \
@@ -49,8 +49,24 @@ sudo apt install libwebkit2gtk-4.0-dev \
     libssl-dev \
     libgtk-3-dev \
     libayatana-appindicator3-dev \
-    librsvg2-dev
+    librsvg2-dev \
+    libsoup2.4-dev \
+    libfuse2
 ```
+
+**Note on Mismatched Dependencies:** Some distributions may provide newer versions of libraries than what the build system expects (e.g., `libwebkit2gtk-4.1-dev` instead of `4.0`). If you encounter build errors related to missing `*.pc` or `*.so` files for versions ending in `-4.0`, you may need to create symbolic links as a workaround. For example:
+
+```bash
+# For pkg-config files
+sudo ln -s /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.1.pc /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.0.pc
+sudo ln -s /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.1.pc /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.0.pc
+
+# For shared library files
+sudo ln -s /usr/lib/x86_64-linux-gnu/libwebkit2gtk-4.1.so /usr/lib/x86_64-linux-gnu/libwebkit2gtk-4.0.so
+sudo ln -s /usr/lib/x86_64-linux-gnu/libjavascriptcoregtk-4.1.so /usr/lib/x86_64-linux-gnu/libjavascriptcoregtk-4.0.so
+```
+
+**Known Issues:** The AppImage bundle may fail to build with an `error running appimage.sh` message. The `.deb` and `.rpm` bundles are not affected by this issue.
 
 #### Linux (Fedora)
 

--- a/heaven-gui/src-tauri/src/commands.rs
+++ b/heaven-gui/src-tauri/src/commands.rs
@@ -11,8 +11,8 @@ use serde_json::{json, Map, Value};
 use uuid::Uuid;
 
 use crate::{
-    get_repos_dir, get_settings_path, get_state_dir, AIOperation, GlobalState, PromotionRecord,
-    RepositoryState, TestRun, WorkpadState,
+    get_state_dir, list_test_runs, AIOperation, GlobalState, PromotionRecord, RepositoryState,
+    TestRun, WorkpadState,
 };
 
 fn read_json<T: DeserializeOwned>(path: &Path) -> Result<Option<T>, String> {


### PR DESCRIPTION
The `heaven-gui` application was failing to build on Linux due to several issues:
- The `BUILDING.md` file was missing several required system dependencies (`libwebkit2gtk-4.1-dev`, `libsoup2.4-dev`, `libfuse2`).
- The build script was sensitive to specific versions of `webkit2gtk` and `javascriptcoregtk`, causing failures on systems with newer versions.
- A Rust compilation error was present in the backend due to incorrect import statements.

This commit resolves these issues by:
- Updating `heaven-gui/BUILDING.md` to include all necessary dependencies.
- Adding instructions to `BUILDING.md` for creating symbolic links as a workaround for the library version mismatch issue.
- Fixing the incorrect import statement in `heaven-gui/src-tauri/src/commands.rs`.

With these changes, the GUI now builds successfully in both development and production modes, with the exception of the AppImage bundle, which has been noted as a known issue.