### PR TITLE
Use single temporary patch path

### DIFF
--- a/heaven-gui/src-tauri/src/commands.rs
+++ b/heaven-gui/src-tauri/src/commands.rs
@@ -340,11 +340,10 @@ pub(crate) fn apply_patch(
         .write_all(diff.as_bytes())
         .map_err(|e| format!("Failed to write patch diff: {}", e))?;
 
-    let patch_path = temp_file.path().to_path_buf();
-    temp_file.keep().map_err(|e| {
+    let (_file, patch_path) = temp_file.keep().map_err(|e| {
         format!(
             "Failed to persist temporary patch {}: {}",
-            patch_path.display(),
+            e.file.path().display(),
             e.error
         )
     })?;


### PR DESCRIPTION
## Summary
- replace manual UUID-named patch file creation with `tempfile::Builder`
- reuse the temporary file's path for the CLI patch argument instead of renaming
- clean up the temporary patch file after invoking the CLI command

## Testing
- cargo fmt --manifest-path heaven-gui/src-tauri/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68f86f1b176c832ba2d2bbe74cbee109