### PR TITLE
Include tests.log_dir in save_config output

### DIFF
--- a/sologit/config/manager.py
+++ b/sologit/config/manager.py
@@ -640,7 +640,8 @@ class ConfigManager:
                 'parallel_max': self.config.tests.parallel_max,
                 'fast_tests': self.config.tests.fast_tests,
                 'full_tests': self.config.tests.full_tests,
-                'smoke_tests': self.config.tests.smoke_tests
+                'smoke_tests': self.config.tests.smoke_tests,
+                'log_dir': self.config.tests.log_dir,
             },
             'ci': asdict(self.config.ci),
             'repos_path': self.config.repos_path,


### PR DESCRIPTION
## Summary
- include the tests.log_dir field when serializing configuration so save_config matches to_dict

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f87fad5da8832b958b8b64f1f0cf3c