### PR TITLE
Add coverage tests for CLI main module

### DIFF
--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -181,7 +181,7 @@ def test_main_uses_interactive_shell(cli_main, monkeypatch):
     called = {}
 
     monkeypatch.setattr(cli_main, "_run_interactive_shell", lambda: called.setdefault("shell", 0))
-    monkeypatch.setattr(cli_main, "_execute_cli_command", lambda args: called.setdefault("cmd", args))
+    monkeypatch.setattr(cli_main, "_execute_cli_command", lambda args: called.__setitem__("cmd", args))
 
     monkeypatch.setattr(cli_main.sys, "argv", ["evogitctl"])
 


### PR DESCRIPTION
## Summary
- add stubs that allow loading the CLI entrypoint without the unparseable command modules
- exercise helper flows in `sologit.cli.main` including GUI resolution, abort handling, history integration, and interactive startup

## Testing
- pytest tests/test_cli_main.py

------
https://chatgpt.com/codex/tasks/task_e_68f8a8353910832bb2035650a9aab904