### PR TITLE
Add verification for StateBackend ABC contract

### DIFF
--- a/sologit/state/__init__.py
+++ b/sologit/state/__init__.py
@@ -20,7 +20,7 @@ from sologit.state.schema import (
     EventType,
     StateEvent,
 )
-from sologit.state.manager import StateManager
+from sologit.state.manager import JSONStateBackend, StateBackend, StateManager
 
 __all__ = [
     'WorkpadStatus',
@@ -35,5 +35,7 @@ __all__ = [
     'GlobalState',
     'EventType',
     'StateEvent',
+    'StateBackend',
+    'JSONStateBackend',
     'StateManager',
 ]

--- a/tests/test_state_backend_abc.py
+++ b/tests/test_state_backend_abc.py
@@ -1,0 +1,26 @@
+"""Tests for the StateBackend abstract base class implementation."""
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from sologit.state.manager import JSONStateBackend, StateBackend
+
+
+def test_state_backend_is_abstract() -> None:
+    """StateBackend should behave as an abstract base class."""
+    assert inspect.isabstract(StateBackend)
+    with pytest.raises(TypeError):
+        StateBackend()  # type: ignore[abstract]
+
+
+def test_json_state_backend_implements_contract(tmp_path: Path) -> None:
+    """Concrete JSON backend should be instantiable and non-abstract."""
+    assert not inspect.isabstract(JSONStateBackend)
+    backend = JSONStateBackend(tmp_path)
+
+    # Basic smoke test for implemented methods to ensure no NotImplementedError stubs remain
+    backend.write_global_state(backend.read_global_state())
+    assert backend.list_repositories() == []
+    assert backend.list_workpads() == []


### PR DESCRIPTION
## Summary
- expose the StateBackend and JSONStateBackend classes from the state package
- add tests confirming the StateBackend ABC contract and that JSONStateBackend fulfills it

## Testing
- pytest tests/test_state_backend_abc.py

------
https://chatgpt.com/codex/tasks/task_e_68f8a8b116c0832b83302a8912b3f2d4