### PR TITLE
Add return type hints across Solo Git modules

### DIFF
--- a/sologit/analysis/test_analyzer.py
+++ b/sologit/analysis/test_analyzer.py
@@ -106,7 +106,7 @@ class TestAnalyzer:
         ]
     }
     
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize analyzer."""
         logger.info("TestAnalyzer initialized")
     

--- a/sologit/api/client.py
+++ b/sologit/api/client.py
@@ -48,7 +48,7 @@ class ChatResponse:
     tokens_used: int = 0
     raw: Optional[Dict[str, Any]] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if not self.total_tokens:
             self.total_tokens = self.prompt_tokens + self.completion_tokens
         if not self.tokens_used:

--- a/sologit/cli/enhanced_commands.py
+++ b/sologit/cli/enhanced_commands.py
@@ -27,7 +27,7 @@ StageResult = TypeVar("StageResult")
 class EnhancedCLI:
     """Enhanced CLI with Rich formatting and state management."""
     
-    def __init__(self):
+    def __init__(self) -> None:
         self.formatter = RichFormatter()
         self.state_manager = StateManager()
         self.graph_renderer = CommitGraphRenderer(self.formatter.console)

--- a/sologit/cli/integrated_commands.py
+++ b/sologit/cli/integrated_commands.py
@@ -74,7 +74,7 @@ def get_test_orchestrator() -> TestOrchestrator:
 
 
 @click.group()
-def workpad():
+def workpad() -> None:
     """Workpad lifecycle management (integrated)."""
     pass
 
@@ -83,7 +83,7 @@ def workpad():
 @click.argument('title')
 @click.option('--repo', 'repo_id', type=str, help='Repository ID (auto-selects if only one)')
 @click.pass_context
-def workpad_create(ctx, title: str, repo_id: Optional[str]):
+def workpad_create(ctx: click.Context, title: str, repo_id: Optional[str]) -> None:
     """
     Create a new workpad (ephemeral workspace).
     
@@ -157,7 +157,9 @@ def workpad_create(ctx, title: str, repo_id: Optional[str]):
 @click.option('--status', type=click.Choice(['active', 'promoted', 'deleted']), 
               help='Filter by status')
 @click.pass_context
-def workpad_list(ctx, repo_id: Optional[str], status: Optional[str]):
+def workpad_list(
+    ctx: click.Context, repo_id: Optional[str], status: Optional[str]
+) -> None:
     """
     List all workpads.
     
@@ -218,7 +220,7 @@ def workpad_list(ctx, repo_id: Optional[str], status: Optional[str]):
 @workpad.command('status')
 @click.argument('workpad_id', required=False)
 @click.pass_context
-def workpad_status(ctx, workpad_id: Optional[str]):
+def workpad_status(ctx: click.Context, workpad_id: Optional[str]) -> None:
     """
     Show detailed workpad status.
     
@@ -319,7 +321,7 @@ def workpad_status(ctx, workpad_id: Optional[str]):
 @click.argument('workpad_id', required=False)
 @click.option('--base', default='trunk', help='Base branch to diff against')
 @click.pass_context
-def workpad_diff(ctx, workpad_id: Optional[str], base: str):
+def workpad_diff(ctx: click.Context, workpad_id: Optional[str], base: str) -> None:
     """
     Show diff for workpad.
     
@@ -357,7 +359,9 @@ def workpad_diff(ctx, workpad_id: Optional[str], base: str):
 @click.argument('workpad_id', required=False)
 @click.option('--force', is_flag=True, help='Force promote without test check')
 @click.pass_context
-def workpad_promote(ctx, workpad_id: Optional[str], force: bool):
+def workpad_promote(
+    ctx: click.Context, workpad_id: Optional[str], force: bool
+) -> None:
     """
     Promote workpad to trunk (merge).
     
@@ -415,7 +419,7 @@ def workpad_promote(ctx, workpad_id: Optional[str], force: bool):
 @click.argument('workpad_id')
 @click.option('--force', is_flag=True, help='Force delete even if not merged')
 @click.pass_context
-def workpad_delete(ctx, workpad_id: str, force: bool):
+def workpad_delete(ctx: click.Context, workpad_id: str, force: bool) -> None:
     """
     Delete a workpad.
     
@@ -453,7 +457,7 @@ def workpad_delete(ctx, workpad_id: str, force: bool):
 
 
 @click.group()
-def ai():
+def ai() -> None:
     """AI-powered operations (integrated)."""
     pass
 
@@ -461,7 +465,7 @@ def ai():
 @ai.command('commit-message')
 @click.option('--pad', 'workpad_id', type=str, help='Workpad ID')
 @click.pass_context
-def ai_commit_message(ctx, workpad_id: Optional[str]):
+def ai_commit_message(ctx: click.Context, workpad_id: Optional[str]) -> None:
     """
     Generate AI commit message from diff.
     
@@ -530,7 +534,7 @@ def ai_commit_message(ctx, workpad_id: Optional[str]):
 @ai.command('review')
 @click.option('--pad', 'workpad_id', type=str, help='Workpad ID')
 @click.pass_context
-def ai_review(ctx, workpad_id: Optional[str]):
+def ai_review(ctx: click.Context, workpad_id: Optional[str]) -> None:
     """
     AI code review for workpad changes.
     
@@ -615,7 +619,7 @@ def ai_review(ctx, workpad_id: Optional[str]):
 
 @ai.command('status')
 @click.pass_context
-def ai_status(ctx):
+def ai_status(ctx: click.Context) -> None:
     """Show AI orchestrator status (models, budget, etc)."""
     config_manager = ctx.obj.get('config')
     
@@ -652,7 +656,7 @@ def ai_status(ctx):
 
 
 @click.group()
-def history():
+def history() -> None:
     """Git history and log commands."""
     pass
 
@@ -662,7 +666,9 @@ def history():
 @click.option('--limit', default=20, help='Number of commits to show')
 @click.option('--branch', type=str, help='Branch name')
 @click.pass_context
-def history_log(ctx, repo_id: Optional[str], limit: int, branch: Optional[str]):
+def history_log(
+    ctx: click.Context, repo_id: Optional[str], limit: int, branch: Optional[str]
+) -> None:
     """
     Show commit history.
     
@@ -719,7 +725,7 @@ def history_log(ctx, repo_id: Optional[str], limit: int, branch: Optional[str]):
 @click.option('--repo', 'repo_id', type=str, help='Repository ID')
 @click.option('--confirm', is_flag=True, help='Skip confirmation prompt')
 @click.pass_context
-def history_revert(ctx, repo_id: Optional[str], confirm: bool):
+def history_revert(ctx: click.Context, repo_id: Optional[str], confirm: bool) -> None:
     """
     Revert last commit on trunk.
     
@@ -769,7 +775,12 @@ def history_revert(ctx, repo_id: Optional[str], confirm: bool):
 @click.option('--file', 'target_file', type=str, help='Target file to create/modify')
 @click.option('--pad', 'workpad_id', type=str, help='Workpad ID')
 @click.pass_context
-def ai_generate(ctx, prompt: str, target_file: Optional[str], workpad_id: Optional[str]):
+def ai_generate(
+    ctx: click.Context,
+    prompt: str,
+    target_file: Optional[str],
+    workpad_id: Optional[str],
+) -> None:
     """
     Generate code using AI.
     
@@ -860,7 +871,12 @@ def ai_generate(ctx, prompt: str, target_file: Optional[str], workpad_id: Option
 @click.option('--pad', 'workpad_id', type=str, help='Workpad ID')
 @click.option('--instruction', type=str, help='Specific refactoring instruction')
 @click.pass_context
-def ai_refactor(ctx, file_path: str, workpad_id: Optional[str], instruction: Optional[str]):
+def ai_refactor(
+    ctx: click.Context,
+    file_path: str,
+    workpad_id: Optional[str],
+    instruction: Optional[str],
+) -> None:
     """
     Refactor code using AI.
     
@@ -933,7 +949,9 @@ def ai_refactor(ctx, file_path: str, workpad_id: Optional[str], instruction: Opt
 @click.option('--pad', 'workpad_id', type=str, help='Workpad ID')
 @click.option('--framework', type=click.Choice(['pytest', 'unittest']), default='pytest')
 @click.pass_context
-def ai_test_gen(ctx, file_path: str, workpad_id: Optional[str], framework: str):
+def ai_test_gen(
+    ctx: click.Context, file_path: str, workpad_id: Optional[str], framework: str
+) -> None:
     """
     Generate tests for code using AI.
     
@@ -1009,7 +1027,12 @@ def ai_test_gen(ctx, file_path: str, workpad_id: Optional[str], framework: str):
 @click.option('--pad', 'workpad_id', type=str, help='Workpad ID')
 @click.option('--message', '-m', type=str, help='Commit message')
 @click.pass_context
-def workpad_apply_patch(ctx, patch_file: Optional[str], workpad_id: Optional[str], message: Optional[str]):
+def workpad_apply_patch(
+    ctx: click.Context,
+    patch_file: Optional[str],
+    workpad_id: Optional[str],
+    message: Optional[str],
+) -> None:
     """
     Apply a patch to workpad.
     
@@ -1069,14 +1092,14 @@ def workpad_apply_patch(ctx, patch_file: Optional[str], workpad_id: Optional[str
 
 
 @click.group()
-def edit():
+def edit() -> None:
     """Edit and history commands (undo/redo)."""
     pass
 
 
 @edit.command('undo')
 @click.pass_context
-def edit_undo(ctx):
+def edit_undo(ctx: click.Context) -> None:
     """
     Undo the last command.
     
@@ -1103,7 +1126,7 @@ def edit_undo(ctx):
 
 @edit.command('redo')
 @click.pass_context
-def edit_redo(ctx):
+def edit_redo(ctx: click.Context) -> None:
     """
     Redo the last undone command.
     
@@ -1132,7 +1155,9 @@ def edit_redo(ctx):
 @click.option('--limit', type=int, default=20, help='Number of entries to show')
 @click.option('--search', type=str, help='Search query')
 @click.pass_context
-def edit_history(ctx, limit: int, search: Optional[str]):
+def edit_history(
+    ctx: click.Context, limit: int, search: Optional[str]
+) -> None:
     """
     Show command history.
     

--- a/sologit/cli/main.py
+++ b/sologit/cli/main.py
@@ -130,7 +130,11 @@ def abort_with_error(
     help="Path to config file (default: ~/.sologit/config.yaml)",
 )
 @click.pass_context
-def cli(ctx, verbose, config):
+def cli(
+    ctx: click.Context,
+    verbose: bool,
+    config: Optional[Path],
+) -> None:
     """
     Solo Git - Frictionless Git workflow for AI-augmented solo developers.
 
@@ -194,7 +198,7 @@ def cli(ctx, verbose, config):
 
 @cli.command()
 @click.pass_context
-def version(ctx):
+def version(ctx: click.Context) -> None:
     """Show version information."""
     formatter.print_header("Solo Git Version")
     version_table = formatter.table(headers=["Component", "Value"])
@@ -215,7 +219,7 @@ def version(ctx):
 
 
 @cli.command()
-def hello():
+def hello() -> None:
     """
     Test command to verify Solo Git is working.
 
@@ -298,7 +302,7 @@ def shortcuts(dev: bool = False) -> None:
 @cli.command()
 @click.option('--dev', is_flag=True, help='Launch in development mode')
 @click.pass_context
-def gui(ctx, dev: bool):
+def gui(ctx: click.Context, dev: bool) -> None:
     """Launch the Heaven Interface GUI."""
     config_manager = ctx.obj.get("config") if ctx and ctx.obj else None
     env = os.environ.copy()
@@ -382,7 +386,7 @@ def _launch_heaven_tui(repo_path: Optional[str] = None) -> None:
 
 @cli.command()
 @click.option('--repo', 'repo_path', type=click.Path(exists=True), help='Repository path')
-def tui(repo_path: Optional[str] = None):
+def tui(repo_path: Optional[str] = None) -> None:
     """
     Launch the Heaven Interface TUI.
 
@@ -419,7 +423,7 @@ def tui(repo_path: Optional[str] = None):
 
 @cli.command()
 @click.option("--repo", "repo_path", type=click.Path(exists=True), help="Repository path")
-def heaven(repo_path: Optional[str]):
+def heaven(repo_path: Optional[str]) -> None:
     """
     Launch the Heaven Interface TUI (Production Version).
 
@@ -481,7 +485,7 @@ def heaven(repo_path: Optional[str]):
 
 
 @cli.command()
-def heaven_legacy():
+def heaven_legacy() -> None:
     """
     Launch the Legacy Enhanced Heaven Interface TUI.
 
@@ -504,7 +508,7 @@ def heaven_legacy():
 
 
 @cli.command()
-def interactive():
+def interactive() -> None:
     """
     Launch interactive shell with autocomplete.
 
@@ -522,7 +526,7 @@ def interactive():
 
 
 @cli.command()
-def undo():
+def undo() -> None:
     """Undo the last undoable command."""
     history = get_command_history()
     entry = history.undo()
@@ -534,7 +538,7 @@ def undo():
 
 
 @cli.command()
-def redo():
+def redo() -> None:
     """Redo the next command if available."""
     history = get_command_history()
     entry = history.redo()
@@ -548,7 +552,7 @@ def redo():
 @cli.command(name="history")
 @click.option("--limit", default=10, show_default=True, type=click.IntRange(1, 1000))
 @click.option("--all", "show_all", is_flag=True, help="Include non-CLI commands.")
-def show_history(limit: int, show_all: bool):
+def show_history(limit: int, show_all: bool) -> None:
     """Display recent command history."""
     history = get_command_history()
 
@@ -589,7 +593,15 @@ def show_history(limit: int, show_all: bool):
 @click.option("--no-promote", is_flag=True, help="Disable automatic promotion")
 @click.option("--target", type=click.Choice(["fast", "full"]), default="fast", help="Test target")
 @click.pass_context
-def pair(ctx, prompt, repo_id, title, no_test, no_promote, target):
+def pair(
+    ctx: click.Context,
+    prompt: Optional[str],
+    repo_id: Optional[str],
+    title: Optional[str],
+    no_test: bool,
+    no_promote: bool,
+    target: str,
+) -> None:
     """
     Start AI pair programming session.
 
@@ -654,7 +666,7 @@ except ImportError as e:
     logger.warning(f"Could not load integrated commands: {e}")
 
 
-def main():
+def main() -> None:
     """Entry point for the CLI."""
     try:
         if len(sys.argv) == 1 and sys.stdin.isatty():

--- a/sologit/config/manager.py
+++ b/sologit/config/manager.py
@@ -184,7 +184,7 @@ class ModelConfig:
             "planning": self.planning.to_dict(),
         }
 
-    def merge_ai_models(self, override: Dict[str, Any]):
+    def merge_ai_models(self, override: Dict[str, Any]) -> None:
         """Merge new-style AI model configuration overrides."""
 
         for tier_name, tier_override in override.items():
@@ -206,7 +206,7 @@ class ModelConfig:
                         fallback_override, defaults
                     )
 
-    def apply_legacy_fields(self, legacy: Dict[str, Any]):
+    def apply_legacy_fields(self, legacy: Dict[str, Any]) -> None:
         """Apply legacy flat model configuration fields."""
 
         if not isinstance(legacy, dict):
@@ -328,7 +328,7 @@ class BudgetConfig:
 
     escalation_triggers: Dict[str, Any] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.escalation_triggers is None:
             self.escalation_triggers = {
                 "patch_lines": 200,
@@ -349,7 +349,7 @@ class TestConfig:
     smoke_tests: list = None
     log_dir: Optional[str] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.fast_tests is None:
             self.fast_tests = []
         if self.full_tests is None:
@@ -388,7 +388,7 @@ class SoloGitConfig:
     ci: CISmokeConfig = None
     deployments: Dict[str, DeploymentCredentials] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.abacus is None:
             self.abacus = AbacusAPIConfig()
         if self.models is None:
@@ -399,7 +399,7 @@ class SoloGitConfig:
             self.tests = TestConfig()
         if self.ci is None:
             self.ci = CISmokeConfig()
-    
+
         if self.deployments is None:
             self.deployments = {}
 
@@ -471,7 +471,7 @@ class ConfigManager:
     DEFAULT_CONFIG_DIR = Path.home() / ".sologit"
     DEFAULT_CONFIG_FILE = DEFAULT_CONFIG_DIR / "config.yaml"
 
-    def __init__(self, config_path: Optional[Path] = None):
+    def __init__(self, config_path: Optional[Path] = None) -> None:
         """
         Initialize configuration manager.
 
@@ -615,7 +615,7 @@ class ConfigManager:
 
         return config
 
-    def save_config(self):
+    def save_config(self) -> None:
         """Save current configuration to file."""
         # Ensure config directory exists
         self.config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -669,7 +669,9 @@ class ConfigManager:
         """Get the current configuration."""
         return self.config
 
-    def set_abacus_credentials(self, api_key: str, endpoint: Optional[str] = None):
+    def set_abacus_credentials(
+        self, api_key: str, endpoint: Optional[str] = None
+    ) -> None:
         """Set Abacus.ai API credentials."""
         self.config.abacus.api_key = api_key
         if endpoint:
@@ -681,7 +683,7 @@ class ConfigManager:
         name: str,
         deployment_id: str,
         deployment_token: str,
-    ):
+    ) -> None:
         """Persist deployment credentials for an Abacus.ai deployment."""
         if not self.config.deployments:
             self.config.deployments = {}
@@ -724,7 +726,7 @@ class ConfigManager:
 
         return len(errors) == 0, errors
 
-    def _build_fernet(self):
+    def _build_fernet(self) -> Optional[Fernet]:
         """Initialise Fernet instance if encryption key is available."""
         secret = os.getenv('SOLOGIT_CONFIG_SECRET')
         if not secret:

--- a/sologit/core/repository.py
+++ b/sologit/core/repository.py
@@ -43,7 +43,7 @@ class Repository:
     last_activity: datetime = field(default_factory=datetime.now)
     """Last activity timestamp"""
     
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Ensure path is a Path object."""
         if isinstance(self.path, str):
             self.path = Path(self.path)

--- a/sologit/engines/git_engine.py
+++ b/sologit/engines/git_engine.py
@@ -47,7 +47,7 @@ class CannotPromoteError(GitEngineError):
 class GitEngine:
     """Core Git operations engine."""
     
-    def __init__(self, data_dir: Optional[Path] = None):
+    def __init__(self, data_dir: Optional[Path] = None) -> None:
         """
         Initialize Git Engine.
         

--- a/sologit/engines/patch_engine.py
+++ b/sologit/engines/patch_engine.py
@@ -38,7 +38,7 @@ class PatchEngine:
     Integrates with GitEngine to apply code changes to workpads.
     """
     
-    def __init__(self, git_engine: GitEngine):
+    def __init__(self, git_engine: GitEngine) -> None:
         """
         Initialize Patch Engine.
         

--- a/sologit/engines/test_orchestrator.py
+++ b/sologit/engines/test_orchestrator.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 try:  # pragma: no cover - platform-specific dependency
     import resource  # type: ignore
@@ -88,7 +88,9 @@ class TestOrchestrator:
         logger.info("TestOrchestrator initialized in subprocess mode")
 
     @contextmanager
-    def _progress(self, description: str, total: Optional[int] = None):
+    def _progress(
+        self, description: str, total: Optional[int] = None
+    ) -> Iterator[Optional[Tuple[Any, int]]]:
         """Create a scoped progress context if a formatter is available."""
         if not self.formatter:
             yield None
@@ -108,7 +110,7 @@ class TestOrchestrator:
         task_id: Optional[int],
         description: str,
         advance: int = 1,
-    ):
+    ) -> Iterator[None]:
         """Show a spinner for a single orchestration stage."""
         if not progress or task_id is None:
             yield

--- a/sologit/orchestration/ai_orchestrator.py
+++ b/sologit/orchestration/ai_orchestrator.py
@@ -8,11 +8,16 @@ with intelligent model selection and cost management.
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Optional, Dict, Any, List
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 from enum import Enum
 
 from sologit.api.client import AbacusClient, ChatMessage, AbacusAPIError
-from sologit.orchestration.model_router import ModelRouter, ModelTier, ComplexityMetrics
+from sologit.orchestration.model_router import (
+    ComplexityMetrics,
+    ModelConfig,
+    ModelRouter,
+    ModelTier,
+)
 from sologit.orchestration.cost_guard import CostGuard, BudgetConfig
 from sologit.orchestration.planning_engine import PlanningEngine, CodePlan
 from sologit.orchestration.code_generator import CodeGenerator, GeneratedPatch
@@ -70,7 +75,7 @@ class AIOrchestrator:
         self,
         config_manager: Optional[ConfigManager] = None,
         formatter: Optional[RichFormatter] = None,
-    ):
+    ) -> None:
         """
         Initialize AI orchestrator.
         
@@ -101,7 +106,9 @@ class AIOrchestrator:
         logger.info("AIOrchestrator initialized")
     
     @contextmanager
-    def _progress(self, description: str, total: float = 100.0):
+    def _progress(
+        self, description: str, total: float = 100.0
+    ) -> Iterator[Optional[Tuple[Any, int]]]:
         """Provide a progress context for long-running orchestration steps."""
         if not self.formatter:
             yield None
@@ -121,7 +128,7 @@ class AIOrchestrator:
         task_id: Optional[int],
         description: str,
         advance: float,
-    ):
+    ) -> Iterator[None]:
         """Context manager that renders a spinner for a single stage."""
         if not progress or task_id is None:
             yield
@@ -675,7 +682,7 @@ class AIOrchestrator:
             'api_configured': bool(self.config.abacus.api_key)
         }
     
-    def _find_model_by_name(self, name: str):
+    def _find_model_by_name(self, name: str) -> Optional[ModelConfig]:
         """Find a model configuration by name."""
         for tier_models in self.model_router.models.values():
             for model in tier_models:

--- a/sologit/orchestration/code_generator.py
+++ b/sologit/orchestration/code_generator.py
@@ -72,7 +72,7 @@ Example patch format:
 
 Only output the patch itself, no explanatory text outside the diff."""
     
-    def __init__(self, client: AbacusClient):
+    def __init__(self, client: AbacusClient) -> None:
         """
         Initialize code generator.
 

--- a/sologit/orchestration/cost_guard.py
+++ b/sologit/orchestration/cost_guard.py
@@ -75,7 +75,7 @@ class CostTracker:
     Tracks AI API costs and usage statistics.
     """
     
-    def __init__(self, storage_path: Optional[Path] = None):
+    def __init__(self, storage_path: Optional[Path] = None) -> None:
         """
         Initialize cost tracker.
         
@@ -90,7 +90,7 @@ class CostTracker:
         
         self._load_history()
     
-    def _load_history(self):
+    def _load_history(self) -> None:
         """Load usage history from disk."""
         if self.storage_path.exists():
             try:
@@ -109,7 +109,7 @@ class CostTracker:
             self.usage_history[today] = DailyUsage(date=today)
         self.current_usage = self.usage_history[today]
     
-    def _save_history(self):
+    def _save_history(self) -> None:
         """Save usage history to disk."""
         try:
             data = {
@@ -122,7 +122,7 @@ class CostTracker:
         except Exception as e:
             logger.error("Failed to save usage history: %s", e)
     
-    def record_usage(self, usage: TokenUsage):
+    def record_usage(self, usage: TokenUsage) -> None:
         """
         Record a token usage event.
         
@@ -221,7 +221,7 @@ class CostGuard:
         config: BudgetConfig,
         tracker: Optional[CostTracker] = None,
         status_path: Optional[Path] = None,
-    ):
+    ) -> None:
         """
         Initialize cost guard.
 
@@ -280,7 +280,7 @@ class CostGuard:
 
         return status
 
-    def _save_status(self):
+    def _save_status(self) -> None:
         """Persist current status to disk."""
 
         try:
@@ -289,7 +289,7 @@ class CostGuard:
         except Exception as exc:
             logger.error("Failed to persist budget status: %s", exc)
 
-    def _record_alert(self, level: str, message: str, projected_cost: float):
+    def _record_alert(self, level: str, message: str, projected_cost: float) -> None:
         """Record an alert entry if not already captured today."""
 
         alerts: List[Dict[str, Any]] = self._status.setdefault('alerts', [])
@@ -306,7 +306,7 @@ class CostGuard:
         )
         self._save_status()
 
-    def _update_status_cost(self, current_cost: float, projected_cost: float):
+    def _update_status_cost(self, current_cost: float, projected_cost: float) -> None:
         """Update status values and persist."""
 
         self._status['current_cost'] = round(current_cost, 4)
@@ -314,7 +314,7 @@ class CostGuard:
         self._status['last_updated'] = datetime.now().isoformat()
         self._save_status()
 
-    def _reset_if_new_day(self):
+    def _reset_if_new_day(self) -> None:
         """Reset status when day changes."""
 
         today = date.today().isoformat()
@@ -374,7 +374,7 @@ class CostGuard:
         completion_tokens: int,
         cost_per_1k: float,
         task_type: str = "unknown"
-    ):
+    ) -> None:
         """
         Record API usage.
         

--- a/sologit/orchestration/model_router.py
+++ b/sologit/orchestration/model_router.py
@@ -132,7 +132,9 @@ class ModelRouter:
         'api design', 'schema', 'model', 'interface'
     ]
     
-    def __init__(self, config: Dict[str, Any], git_sync: Optional["GitStateSync"] = None):
+    def __init__(
+        self, config: Dict[str, Any], git_sync: Optional["GitStateSync"] = None
+    ) -> None:
         """
         Initialize model router.
 

--- a/sologit/orchestration/planning_engine.py
+++ b/sologit/orchestration/planning_engine.py
@@ -134,7 +134,7 @@ Respond with a structured JSON plan in this format:
 
 Be specific, practical, and consider the existing codebase structure."""
     
-    def __init__(self, client: AbacusClient):
+    def __init__(self, client: AbacusClient) -> None:
         """
         Initialize planning engine.
 

--- a/sologit/state/git_sync.py
+++ b/sologit/state/git_sync.py
@@ -26,7 +26,9 @@ class GitStateSync:
     every git operation is tracked in the state system and vice versa.
     """
     
-    def __init__(self, state_dir: Optional[Path] = None, data_dir: Optional[Path] = None):
+    def __init__(
+        self, state_dir: Optional[Path] = None, data_dir: Optional[Path] = None
+    ) -> None:
         """
         Initialize Git State Sync.
         

--- a/sologit/ui/autocomplete.py
+++ b/sologit/ui/autocomplete.py
@@ -51,7 +51,7 @@ class SoloGitCompleter(Completer):
         "redo",
     )
 
-    def __init__(self, cli_app: Optional[click.MultiCommand] = None):
+    def __init__(self, cli_app: Optional[click.MultiCommand] = None) -> None:
         self._cli_app = cli_app
         self.commands = self._build_command_list()
 
@@ -99,7 +99,9 @@ class SoloGitCompleter(Completer):
 
         return ordered
 
-    def get_completions(self, document, complete_event):  # type: ignore[override]
+    def get_completions(  # type: ignore[override]
+        self, document: Any, complete_event: Any
+    ) -> Iterable[Completion]:
         """Yield completions that fuzzy-match the current buffer."""
 
         word = document.get_word_before_cursor() or ""
@@ -121,7 +123,7 @@ class SoloGitCompleter(Completer):
 class CommandHistory:
     """Manages command history with persistence."""
 
-    def __init__(self, history_file: Optional[Path] = None):
+    def __init__(self, history_file: Optional[Path] = None) -> None:
         if history_file is None:
             history_file = Path.home() / ".sologit" / "command_history"
 

--- a/sologit/ui/command_palette.py
+++ b/sologit/ui/command_palette.py
@@ -30,7 +30,7 @@ class Command:
     shortcut: Optional[str] = None
     keywords: List[str] = None
     
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.keywords is None:
             self.keywords = []
 
@@ -88,7 +88,7 @@ class FuzzyMatcher:
 class CommandItem(Static):
     """A single command item in the palette."""
     
-    def __init__(self, command: Command, **kwargs):
+    def __init__(self, command: Command, **kwargs) -> None:
         super().__init__(**kwargs)
         self.command = command
     
@@ -164,7 +164,7 @@ class CommandPaletteScreen(ModalScreen):
     }
     """
     
-    def __init__(self, commands: List[Command], **kwargs):
+    def __init__(self, commands: List[Command], **kwargs) -> None:
         super().__init__(**kwargs)
         self.commands = commands
         self.filtered_commands: List[Command] = []
@@ -290,7 +290,7 @@ class CommandPaletteScreen(ModalScreen):
 class CommandRegistry:
     """Registry for managing available commands."""
     
-    def __init__(self):
+    def __init__(self) -> None:
         self.commands: List[Command] = []
         self._setup_default_commands()
     

--- a/sologit/ui/enhanced_tui.py
+++ b/sologit/ui/enhanced_tui.py
@@ -28,7 +28,7 @@ logger = get_logger(__name__)
 class TestOutputWidget(Log):
     """Widget for displaying real-time test output."""
     
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(highlight=True, markup=True)
         self.test_run_id: Optional[str] = None
     
@@ -57,7 +57,7 @@ class CommitGraphWidget(Static):
     
     commits = reactive([])
     
-    def __init__(self, git_sync: GitStateSync):
+    def __init__(self, git_sync: GitStateSync) -> None:
         super().__init__()
         self.git_sync = git_sync
     
@@ -116,7 +116,7 @@ class WorkpadStatusWidget(Static):
     
     workpads = reactive([])
     
-    def __init__(self, git_sync: GitStateSync):
+    def __init__(self, git_sync: GitStateSync) -> None:
         super().__init__()
         self.git_sync = git_sync
     
@@ -180,7 +180,7 @@ class AIActivityWidget(Static):
     
     operations = reactive([])
     
-    def __init__(self, git_sync: GitStateSync):
+    def __init__(self, git_sync: GitStateSync) -> None:
         super().__init__()
         self.git_sync = git_sync
     
@@ -293,7 +293,7 @@ class HeavenTUI(App):
     
     TITLE = "Heaven Interface - Solo Git TUI"
     
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.git_sync = GitStateSync()
     
@@ -423,7 +423,7 @@ class HeavenTUI(App):
         test_output.write_line("[dim]Press any key to continue...[/dim]")
 
 
-def run_enhanced_tui():
+def run_enhanced_tui() -> None:
     """Launch the enhanced Heaven Interface TUI."""
     app = HeavenTUI()
     app.run()

--- a/sologit/ui/file_tree.py
+++ b/sologit/ui/file_tree.py
@@ -4,6 +4,7 @@ File Tree Viewer for Heaven Interface.
 Displays repository file structure with git status indicators.
 """
 
+from textual.app import ComposeResult
 from textual.widgets import Tree, Static
 from textual.reactive import reactive
 from textual import events
@@ -69,13 +70,13 @@ class FileTreeWidget(Static):
     repo_path: reactive[Optional[str]] = reactive(None)
     show_hidden: reactive[bool] = reactive(False)
     
-    def __init__(self, repo_path: Optional[str] = None, **kwargs):
+    def __init__(self, repo_path: Optional[str] = None, **kwargs) -> None:
         super().__init__(**kwargs)
         self._repo_path_value = repo_path
         self.file_statuses: Dict[str, FileStatus] = {}
         self.selected_file: Optional[str] = None
-    
-    def compose(self):
+
+    def compose(self) -> ComposeResult:
         """Compose the file tree."""
         tree = Tree("Repository", id="file-tree")
         tree.show_root = True
@@ -242,7 +243,7 @@ class FileTreeWidget(Static):
 class FileSelected(events.Message):
     """Message emitted when a file is selected."""
     
-    def __init__(self, file_path: str, is_dir: bool):
+    def __init__(self, file_path: str, is_dir: bool) -> None:
         super().__init__()
         self.file_path = file_path
         self.is_dir = is_dir

--- a/sologit/ui/formatter.py
+++ b/sologit/ui/formatter.py
@@ -28,8 +28,8 @@ from sologit.ui.theme import theme
 
 class RichFormatter:
     """Formatter for Rich library output with Heaven Interface styling."""
-    
-    def __init__(self, console: Optional[Console] = None):
+
+    def __init__(self, console: Optional[Console] = None) -> None:
         self.console = console or Console()
         self.theme_obj = theme
     
@@ -277,7 +277,7 @@ class RichFormatter:
 class ProgressContext:
     """Context manager that manages an indeterminate task for scoped progress."""
 
-    def __init__(self, progress: Progress, description: str):
+    def __init__(self, progress: Progress, description: str) -> None:
         self._progress = progress
         self._description = description
         self._task_id: Optional[int] = None

--- a/sologit/ui/graph.py
+++ b/sologit/ui/graph.py
@@ -15,7 +15,7 @@ from sologit.state.schema import CommitNode
 class CommitGraphRenderer:
     """Renders commit graphs in ASCII art format."""
     
-    def __init__(self, console: Optional[Console] = None):
+    def __init__(self, console: Optional[Console] = None) -> None:
         self.console = console or Console()
         self.theme = theme
     

--- a/sologit/ui/heaven_tui.py
+++ b/sologit/ui/heaven_tui.py
@@ -42,7 +42,7 @@ class StatusBar(Static):
     }
     """
     
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self.repo_name = "No repository"
         self.workpad_name = "No workpad"
@@ -62,7 +62,9 @@ class StatusBar(Static):
             f"│  {shortcuts}"
         )
     
-    def update_context(self, repo_name: str, workpad_name: str = None, test_status: str = "○"):
+    def update_context(
+        self, repo_name: str, workpad_name: Optional[str] = None, test_status: str = "○"
+    ) -> None:
         """Update status bar context."""
         self.repo_name = repo_name
         self.workpad_name = workpad_name or "No workpad"
@@ -86,7 +88,7 @@ class CommitGraphPanel(Static):
     }
     """
     
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self.commits: List[Dict[str, Any]] = []
     
@@ -112,7 +114,7 @@ class CommitGraphPanel(Static):
         
         return '\n'.join(lines)
     
-    def update_commits(self, commits: List[Dict[str, Any]]):
+    def update_commits(self, commits: List[Dict[str, Any]]) -> None:
         """Update commit list."""
         self.commits = commits
         self.refresh()
@@ -130,7 +132,7 @@ class WorkpadPanel(Static):
     }
     """
     
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self.workpads: List[Dict[str, Any]] = []
         self.active_workpad: Optional[str] = None
@@ -166,7 +168,9 @@ class WorkpadPanel(Static):
         
         return '\n'.join(lines)
     
-    def update_workpads(self, workpads: List[Dict[str, Any]], active_id: Optional[str] = None):
+    def update_workpads(
+        self, workpads: List[Dict[str, Any]], active_id: Optional[str] = None
+    ) -> None:
         """Update workpad list."""
         self.workpads = workpads
         self.active_workpad = active_id
@@ -185,7 +189,7 @@ class AIActivityPanel(Static):
     }
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self.operations: List[Dict[str, Any]] = []
     
@@ -222,7 +226,7 @@ class AIActivityPanel(Static):
         
         return '\n'.join(lines)
     
-    def update_operations(self, operations: List[Dict[str, Any]]):
+    def update_operations(self, operations: List[Dict[str, Any]]) -> None:
         """Update operations list."""
         self.operations = operations
         self.refresh()
@@ -241,7 +245,7 @@ class AIResponsePanel(Static):
     }
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._title: Optional[str] = None
         self._lines: List[str] = []
@@ -332,7 +336,14 @@ class PromptModal(ModalScreen[Optional[str]]):
     }
     """
 
-    def __init__(self, title: str, message: str, placeholder: str = "", *, default: str = ""):
+    def __init__(
+        self,
+        title: str,
+        message: str,
+        placeholder: str = "",
+        *,
+        default: str = "",
+    ) -> None:
         super().__init__()
         self._title = title
         self._message = message
@@ -418,7 +429,7 @@ class HeavenTUI(App):
         *,
         git_sync: Optional[GitStateSync] = None,
         ai_orchestrator: Optional[AIOrchestrator] = None,
-    ):
+    ) -> None:
         super().__init__()
         self.repo_path = repo_path
         self.git_sync = git_sync or GitStateSync()

--- a/sologit/ui/history.py
+++ b/sologit/ui/history.py
@@ -81,7 +81,7 @@ class CommandHistory:
     undo/redo capabilities with state tracking.
     """
     
-    def __init__(self, history_file: Optional[Path] = None, max_size: int = 1000):
+    def __init__(self, history_file: Optional[Path] = None, max_size: int = 1000) -> None:
         """
         Initialize command history.
         

--- a/sologit/ui/test_runner.py
+++ b/sologit/ui/test_runner.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 
+from textual.app import ComposeResult
 from textual.widgets import Static, ProgressBar, Label
 from textual.containers import Container, Vertical
 from textual.reactive import reactive
@@ -54,7 +55,7 @@ class TestResult:
     timestamp: datetime = None
     log_path: Optional[Path] = None
     
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.timestamp is None:
             self.timestamp = datetime.now()
     
@@ -105,7 +106,7 @@ class TestOutputWidget(Static):
     
     output_lines: reactive[List[str]] = reactive(list, init=False)
     
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._output_buffer = []
         self.auto_scroll = True
@@ -252,7 +253,7 @@ class TestRunner:
 
     __test__ = False
     
-    def __init__(self, repo_path: str):
+    def __init__(self, repo_path: str) -> None:
         self.repo_path = Path(repo_path)
         self.process: Optional[subprocess.Popen] = None
         self.is_running = False
@@ -435,14 +436,14 @@ class TestRunner:
 
 class TestRunnerWidget(Container):
     """Complete test runner widget with output and summary."""
-    
-    def __init__(self, repo_path: str, **kwargs):
+
+    def __init__(self, repo_path: str, **kwargs) -> None:
         super().__init__(**kwargs)
         self.repo_path = repo_path
         self.runner = TestRunner(repo_path)
         self.current_result: Optional[TestResult] = None
-    
-    def compose(self):
+
+    def compose(self) -> ComposeResult:
         """Compose the widget."""
         yield TestSummaryWidget(id="test-summary")
         yield TestOutputWidget(id="test-output")
@@ -455,10 +456,10 @@ class TestRunnerWidget(Container):
         
         output_widget.clear_output()
         
-        def output_callback(line: str):
+        def output_callback(line: str) -> None:
             output_widget.append_output(line)
-        
-        def result_callback(result: TestResult):
+
+        def result_callback(result: TestResult) -> None:
             summary_widget.update_result(result)
             self.current_result = result
         
@@ -483,7 +484,7 @@ class TestRunnerWidget(Container):
 
 class TestsCompleted(events.Message):
     """Message emitted when tests complete."""
-    
-    def __init__(self, result: TestResult):
+
+    def __init__(self, result: TestResult) -> None:
         super().__init__()
         self.result = result

--- a/sologit/ui/theme.py
+++ b/sologit/ui/theme.py
@@ -143,7 +143,7 @@ class HeavenTheme:
     UI rendering across CLI/TUI and GUI.
     """
     
-    def __init__(self):
+    def __init__(self) -> None:
         self.colors = ColorPalette()
         self.typography = Typography()
         self.spacing = Spacing()

--- a/sologit/ui/tui_app.py
+++ b/sologit/ui/tui_app.py
@@ -21,8 +21,8 @@ from sologit.ui.theme import theme
 
 class CommitGraphWidget(Static):
     """Widget displaying commit graph."""
-    
-    def __init__(self, state_manager: StateManager):
+
+    def __init__(self, state_manager: StateManager) -> None:
         super().__init__()
         self.state_manager = state_manager
         self.commits = []
@@ -69,8 +69,8 @@ class CommitGraphWidget(Static):
 
 class WorkpadListWidget(Static):
     """Widget displaying workpad list."""
-    
-    def __init__(self, state_manager: StateManager):
+
+    def __init__(self, state_manager: StateManager) -> None:
         super().__init__()
         self.state_manager = state_manager
         self.workpads = []
@@ -117,8 +117,8 @@ class WorkpadListWidget(Static):
 
 class StatusBarWidget(Static):
     """Widget displaying status bar."""
-    
-    def __init__(self, state_manager: StateManager):
+
+    def __init__(self, state_manager: StateManager) -> None:
         super().__init__()
         self.state_manager = state_manager
     
@@ -147,8 +147,8 @@ class StatusBarWidget(Static):
 
 class LogViewerWidget(Log):
     """Widget for viewing logs."""
-    
-    def __init__(self):
+
+    def __init__(self) -> None:
         super().__init__()
         self.max_lines = 1000
 
@@ -234,7 +234,7 @@ class HeavenTUI(App):
     
     TITLE = "Solo Git - Heaven Interface"
     
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.state_manager = StateManager()
     
@@ -366,7 +366,7 @@ class HeavenTUI(App):
         event.input.value = ""
 
 
-def run_tui():
+def run_tui() -> None:
     """Run the TUI application."""
     app = HeavenTUI()
     app.run()

--- a/sologit/utils/logger.py
+++ b/sologit/utils/logger.py
@@ -8,7 +8,8 @@ Provides structured logging with different levels and formatters.
 import logging
 import sys
 from pathlib import Path
-from typing import Optional
+from types import TracebackType
+from typing import Optional, Type
 
 
 # Color codes for terminal output
@@ -35,11 +36,11 @@ class ColoredFormatter(logging.Formatter):
         'CRITICAL': Colors.RED + Colors.BOLD
     }
     
-    def __init__(self, fmt: Optional[str] = None, use_colors: bool = True):
+    def __init__(self, fmt: Optional[str] = None, use_colors: bool = True) -> None:
         super().__init__(fmt)
         self.use_colors = use_colors and sys.stderr.isatty()
-    
-    def format(self, record):
+
+    def format(self, record: logging.LogRecord) -> str:
         if self.use_colors:
             levelname = record.levelname
             if levelname in self.LEVEL_COLORS:
@@ -49,7 +50,7 @@ class ColoredFormatter(logging.Formatter):
         return super().format(record)
 
 
-def setup_logging(verbose: bool = False, log_file: Optional[Path] = None):
+def setup_logging(verbose: bool = False, log_file: Optional[Path] = None) -> None:
     """
     Setup logging configuration.
     
@@ -115,16 +116,21 @@ def get_logger(name: str) -> logging.Logger:
 class LogContext:
     """Context manager for temporary log level changes."""
     
-    def __init__(self, logger: logging.Logger, level: int):
+    def __init__(self, logger: logging.Logger, level: int) -> None:
         self.logger = logger
         self.level = level
         self.old_level = None
-    
-    def __enter__(self):
+
+    def __enter__(self) -> logging.Logger:
         self.old_level = self.logger.level
         self.logger.setLevel(self.level)
         return self.logger
-    
-    def __exit__(self, exc_type, exc_val, exc_tb):
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         self.logger.setLevel(self.old_level)
 

--- a/sologit/workflows/auto_merge.py
+++ b/sologit/workflows/auto_merge.py
@@ -67,7 +67,7 @@ class AutoMergeWorkflow:
         ci_smoke_tests: Optional[List[TestConfig]] = None,
         ci_config: Optional["CISmokeConfig"] = None,
         rollback_on_ci_red: bool = True,
-    ):
+    ) -> None:
         """
         Initialize auto-merge workflow.
         

--- a/sologit/workflows/ci_orchestrator.py
+++ b/sologit/workflows/ci_orchestrator.py
@@ -61,7 +61,7 @@ class CIOrchestrator:
         self,
         git_engine: GitEngine,
         test_orchestrator: TestOrchestrator
-    ):
+    ) -> None:
         """
         Initialize CI orchestrator.
         

--- a/sologit/workflows/promotion_gate.py
+++ b/sologit/workflows/promotion_gate.py
@@ -58,11 +58,11 @@ class PromotionDecision:
     warnings: List[str] = field(default_factory=list)
     can_promote: bool = False
     
-    def add_reason(self, reason: str):
+    def add_reason(self, reason: str) -> None:
         """Add a reason for the decision."""
         self.reasons.append(reason)
-    
-    def add_warning(self, warning: str):
+
+    def add_warning(self, warning: str) -> None:
         """Add a warning."""
         self.warnings.append(warning)
 
@@ -78,7 +78,7 @@ class PromotionGate:
         self,
         git_engine: GitEngine,
         rules: Optional[PromotionRules] = None
-    ):
+    ) -> None:
         """
         Initialize promotion gate.
         

--- a/sologit/workflows/rollback_handler.py
+++ b/sologit/workflows/rollback_handler.py
@@ -35,10 +35,10 @@ class RollbackHandler:
     3. Allows developer to fix and retry
     """
     
-    def __init__(self, git_engine: GitEngine):
+    def __init__(self, git_engine: GitEngine) -> None:
         """
         Initialize rollback handler.
-        
+
         Args:
             git_engine: GitEngine instance
         """
@@ -177,7 +177,7 @@ class CIMonitor:
         self,
         git_engine: GitEngine,
         rollback_handler: RollbackHandler
-    ):
+    ) -> None:
         """
         Initialize CI monitor.
         


### PR DESCRIPTION
## Summary
- add explicit return type hints to functions across the CLI, orchestration, UI, and workflow modules
- ensure helper classes such as formatters, engines, and context managers advertise `None` or specific return types
- update type-dependent imports where necessary to support the new annotations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f8a9ef62b0832bbf3384ddd48fdd4d