### PR TITLE
Fix skip-only test runs reporting as failures

### DIFF
--- a/sologit/engines/test_orchestrator.py
+++ b/sologit/engines/test_orchestrator.py
@@ -859,12 +859,16 @@ class TestOrchestrator:
     def get_summary(self, results: List[TestResult]) -> dict:
         """Get test results summary."""
 
+        failed = sum(1 for r in results if r.status == TestStatus.FAILED)
+        timeout = sum(1 for r in results if r.status == TestStatus.TIMEOUT)
+        error = sum(1 for r in results if r.status == TestStatus.ERROR)
+
         return {
             "total": len(results),
             "passed": sum(1 for r in results if r.status == TestStatus.PASSED),
-            "failed": sum(1 for r in results if r.status == TestStatus.FAILED),
-            "timeout": sum(1 for r in results if r.status == TestStatus.TIMEOUT),
-            "error": sum(1 for r in results if r.status == TestStatus.ERROR),
+            "failed": failed,
+            "timeout": timeout,
+            "error": error,
             "skipped": sum(1 for r in results if r.status == TestStatus.SKIPPED),
-            "status": "green" if self.all_tests_passed(results) else "red",
+            "status": "green" if not any([failed, timeout, error]) else "red",
         }

--- a/tests/test_test_orchestrator_comprehensive.py
+++ b/tests/test_test_orchestrator_comprehensive.py
@@ -160,6 +160,43 @@ async def test_parallel_invokes_callbacks(tmp_path: Path, mock_git_engine: Mock)
     assert any(stream == "stdout" for _, stream, _ in seen_lines)
 
 
+def test_get_summary_treats_skips_as_success(tmp_path: Path, mock_git_engine: Mock) -> None:
+    orchestrator = make_orchestrator(mock_git_engine, tmp_path, mode="subprocess")
+
+    results = [
+        TestResult(name="passed", status=TestStatus.PASSED, duration_ms=5),
+        TestResult(name="skipped", status=TestStatus.SKIPPED, duration_ms=1, error="dependency"),
+    ]
+
+    summary = orchestrator.get_summary(results)
+
+    assert summary == {
+        "total": 2,
+        "passed": 1,
+        "failed": 0,
+        "timeout": 0,
+        "error": 0,
+        "skipped": 1,
+        "status": "green",
+    }
+
+
+def test_get_summary_marks_red_when_failures(tmp_path: Path, mock_git_engine: Mock) -> None:
+    orchestrator = make_orchestrator(mock_git_engine, tmp_path, mode="subprocess")
+
+    results = [
+        TestResult(name="passed", status=TestStatus.PASSED, duration_ms=5),
+        TestResult(name="failed", status=TestStatus.FAILED, duration_ms=3, exit_code=1),
+        TestResult(name="skipped", status=TestStatus.SKIPPED, duration_ms=1),
+    ]
+
+    summary = orchestrator.get_summary(results)
+
+    assert summary["failed"] == 1
+    assert summary["skipped"] == 1
+    assert summary["status"] == "red"
+
+
 @pytest.mark.asyncio
 async def test_collects_metrics(tmp_path: Path, mock_git_engine: Mock):
     orchestrator = make_orchestrator(mock_git_engine, tmp_path, mode="subprocess")


### PR DESCRIPTION
## Summary
- update the TestOrchestrator summary logic to only flag failures when tests actually fail, error, or time out
- add regression tests to ensure skipped results keep the summary green and failures still mark it red

## Testing
- pytest tests/test_test_orchestrator_comprehensive.py::test_get_summary_treats_skips_as_success tests/test_test_orchestrator_comprehensive.py::test_get_summary_marks_red_when_failures

------
https://chatgpt.com/codex/tasks/task_e_68ffb8d7baf0832bbd47650a380af76a