### PR TITLE
Simplify 429 retry test side effect handling

### DIFF
--- a/tests/test_api_client_comprehensive.py
+++ b/tests/test_api_client_comprehensive.py
@@ -229,19 +229,15 @@ def test_post_429_retries_with_retry_after_header(client):
     mock_response_200.status_code = 200
     mock_response_200.json.return_value = {'success': True, 'data': 'test'}
     
-    call_count = 0
-    def side_effect(*args, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            return mock_response_429
-        return mock_response_200
-    
-    with patch.object(client.session, 'post', side_effect=side_effect):
+    with patch.object(
+        client.session,
+        'post',
+        side_effect=[mock_response_429, mock_response_200]
+    ) as mock_post:
         with patch('time.sleep'):  # Mock sleep to speed up test
             result = client._post('/test', {})
             assert result['data'] == 'test'
-            assert call_count == 2
+            assert mock_post.call_count == 2
 
 
 def test_post_503_retries_with_exponential_backoff(client):


### PR DESCRIPTION
## Summary
- replace the manual call counter in the 429 retry test with a list-based side effect
- assert the number of retry attempts using the mock's call count

## Testing
- pytest tests/test_api_client_comprehensive.py::test_post_429_retries_with_retry_after_header -q

------
https://chatgpt.com/codex/tasks/task_e_68ffbc8a108c832bb0727735535baa67