### PR TITLE
Fix syntax error in ai_orchestrator.py: remove duplicate select_model call

### DIFF
--- a/sologit/orchestration/ai_orchestrator.py
+++ b/sologit/orchestration/ai_orchestrator.py
@@ -280,9 +280,6 @@ class AIOrchestrator:
                         select_context['plan'] = plan
                     if file_contents:
                         select_context['file_contents'] = file_contents
-                    model_config = self.model_router.select_model(
-                        task_description,
-                        context=select_context,
                     context = {
                         'task_type': TaskType.CODING.value,
                         'plan': str(code_plan),


### PR DESCRIPTION
## Summary
Fixed syntax error in `sologit/orchestration/ai_orchestrator.py` at lines 283-294.

## Problem
- Duplicate code with unclosed parenthesis in `select_model()` call
- Syntax error introduced by PR #186 after previous fixes
- Prevented proper Python compilation

## Solution
- Removed duplicate incomplete `select_model()` call (lines 283-285)
- Kept the complete, properly formatted call with correct context dictionary
- All Python files now pass syntax validation

## Verification
✅ Syntax check passed on ai_orchestrator.py
✅ Full repository syntax check passed (compileall)
✅ Module imports successfully without syntax errors

## Related
- Follows up on merged PR #180
- Fixes regression from PR #186