### PR TITLE
feat: Add rebase, snapshot, and gist integration features

### DIFF
--- a/sologit/cli/commands.py
+++ b/sologit/cli/commands.py
@@ -15,8 +15,8 @@ import click
 from rich.console import Console
 
 from sologit.config.manager import ConfigManager
-from sologit.engines.git_engine import GitEngine, GitEngineError
-from sologit.engines.patch_engine import PatchEngine
+from sologit.engines.git_engine import GitEngine, GitEngineError, RebaseConflictError, SnapshotNotFoundError
+from sologit.engines.patch_engine import PatchEngine, GistError
 from sologit.engines.test_orchestrator import (
     TestConfig,
     TestOrchestrator,
@@ -623,6 +623,36 @@ def pad_promote(pad_id: str) -> None:
         abort_with_error("Promotion failed", str(e))
 
 
+@pad.command('rebase')
+@click.argument('pad_id')
+@click.option('--interactive', is_flag=True, help='Perform an interactive rebase.')
+def pad_rebase(pad_id: str, interactive: bool) -> None:
+    """Rebase a workpad on top of the trunk branch."""
+    git_engine = get_git_engine()
+
+    workpad = git_engine.get_workpad(pad_id)
+    if not workpad:
+        abort_with_error(f"Workpad {pad_id} not found")
+
+    formatter.print_header("Workpad Rebase")
+    formatter.print_info(f"Rebasing workpad: {workpad.title}")
+
+    try:
+        git_engine.rebase_workpad(pad_id, interactive=interactive)
+        formatter.print_success("Rebase successful!")
+        formatter.print_info(f"Workpad '{workpad.title}' is now up to date with the trunk.")
+    except RebaseConflictError as e:
+        abort_with_error(
+            "Rebase failed due to conflicts.",
+            str(e),
+            title="Rebase Aborted",
+            help_text="Please resolve the conflicts manually in your local repository.",
+            tip="Use 'git status' to see the conflicting files, and 'git rebase --abort' to cancel the rebase.",
+        )
+    except GitEngineError as e:
+        abort_with_error("Rebase failed", str(e))
+
+
 @pad.command('diff')
 @click.argument('pad_id')
 def pad_diff(pad_id: str) -> None:
@@ -642,6 +672,89 @@ def pad_diff(pad_id: str) -> None:
             formatter.print_info("No changes between workpad and trunk.")
     except GitEngineError as e:
         abort_with_error("Failed to generate diff", str(e))
+
+
+@pad.group('snapshot')
+def pad_snapshot() -> None:
+    """Manage workpad snapshots."""
+    pass
+
+
+@pad_snapshot.command('create')
+@click.argument('pad_id')
+@click.option('-m', '--message', required=True, help='A descriptive message for the snapshot.')
+def snapshot_create(pad_id: str, message: str) -> None:
+    """Create a new snapshot for a workpad."""
+    git_engine = get_git_engine()
+    try:
+        snapshot_id = git_engine.create_snapshot(pad_id, message)
+        formatter.print_success(f"Snapshot '{snapshot_id}' created for workpad {pad_id}.")
+    except (WorkpadNotFoundError, GitEngineError) as e:
+        abort_with_error(str(e))
+
+
+@pad_snapshot.command('list')
+@click.argument('pad_id')
+def snapshot_list(pad_id: str) -> None:
+    """List all snapshots for a workpad."""
+    git_engine = get_git_engine()
+    try:
+        snapshots = git_engine.list_snapshots(pad_id)
+        if not snapshots:
+            formatter.print_info("No snapshots found for this workpad.")
+            return
+
+        table = formatter.table(headers=["ID", "Message", "Created"])
+        for snapshot in snapshots:
+            table.add_row(snapshot.id, snapshot.message, snapshot.created_at.strftime('%Y-%m-%d %H:%M'))
+        formatter.console.print(table)
+    except (WorkpadNotFoundError, GitEngineError) as e:
+        abort_with_error(str(e))
+
+
+@pad_snapshot.command('restore')
+@click.argument('pad_id')
+@click.argument('snapshot_id')
+def snapshot_restore(pad_id: str, snapshot_id: str) -> None:
+    """Restore a workpad to a specific snapshot."""
+    git_engine = get_git_engine()
+    try:
+        git_engine.restore_snapshot(pad_id, snapshot_id)
+        formatter.print_success(f"Workpad {pad_id} restored to snapshot '{snapshot_id}'.")
+    except (WorkpadNotFoundError, SnapshotNotFoundError, GitEngineError) as e:
+        abort_with_error(str(e))
+
+
+@pad_snapshot.command('delete')
+@click.argument('pad_id')
+@click.argument('snapshot_id')
+def snapshot_delete(pad_id: str, snapshot_id: str) -> None:
+    """Delete a specific snapshot."""
+    git_engine = get_git_engine()
+    try:
+        git_engine.delete_snapshot(pad_id, snapshot_id)
+        formatter.print_success(f"Snapshot '{snapshot_id}' deleted from workpad {pad_id}.")
+    except (WorkpadNotFoundError, SnapshotNotFoundError, GitEngineError) as e:
+        abort_with_error(str(e))
+
+
+@pad.command('patch')
+@click.argument('pad_id')
+@click.option('--gist', 'gist_url', help='URL of a GitHub Gist containing the patch.')
+@click.option('-m', '--message', help='Commit message for the patch.')
+def pad_patch(pad_id: str, gist_url: Optional[str], message: Optional[str]) -> None:
+    """Apply a patch to a workpad from a Gist."""
+    if not gist_url:
+        abort_with_error("You must provide a Gist URL using the --gist option.")
+
+    patch_engine = get_patch_engine()
+    commit_message = message or f"Apply patch from {gist_url}"
+
+    try:
+        checkpoint_id = patch_engine.apply_patch_from_gist(pad_id, gist_url, commit_message)
+        formatter.print_success(f"Patch from Gist applied successfully. New checkpoint: {checkpoint_id}")
+    except (GistError, WorkpadNotFoundError, GitEngineError) as e:
+        abort_with_error(str(e))
 
 
 @click.group()

--- a/sologit/core/workpad.py
+++ b/sologit/core/workpad.py
@@ -8,7 +8,34 @@ branches. They are automatically named, tracked, and cleaned up.
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
+
+class SnapshotNotFoundError(Exception):
+    """Raised when a snapshot is not found."""
+    pass
+
+
+@dataclass
+class Snapshot:
+    """Represents a snapshot of a workpad's state."""
+    id: str
+    message: str
+    created_at: datetime = field(default_factory=datetime.now)
+
+    def to_dict(self) -> dict:
+        return {
+            'id': self.id,
+            'message': self.message,
+            'created_at': self.created_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Snapshot":
+        return cls(
+            id=data['id'],
+            message=data['message'],
+            created_at=datetime.fromisoformat(data['created_at']),
+        )
 
 
 @dataclass
@@ -44,6 +71,9 @@ class Workpad:
     
     last_commit: Optional[str] = None
     """Last commit hash in workpad"""
+
+    snapshots: Dict[str, Snapshot] = field(default_factory=dict)
+    """A dictionary of snapshots, with snapshot ID as the key."""
     
     def to_dict(self) -> dict:
         """Convert to dictionary for serialization."""
@@ -58,11 +88,14 @@ class Workpad:
             "status": self.status,
             "test_status": self.test_status,
             "last_commit": self.last_commit,
+            "snapshots": {sid: s.to_dict() for sid, s in self.snapshots.items()},
         }
     
     @classmethod
     def from_dict(cls, data: dict) -> "Workpad":
         """Create from dictionary."""
+        snapshots_data = data.get("snapshots", {})
+        snapshots = {sid: Snapshot.from_dict(sdata) for sid, sdata in snapshots_data.items()}
         return cls(
             id=data["id"],
             repo_id=data["repo_id"],
@@ -76,6 +109,7 @@ class Workpad:
             status=data.get("status", "active"),
             test_status=data.get("test_status"),
             last_commit=data.get("last_commit"),
+            snapshots=snapshots,
         )
 
 

--- a/sologit/engines/git_engine.py
+++ b/sologit/engines/git_engine.py
@@ -18,7 +18,7 @@ from zipfile import ZipFile
 from git import Repo, GitCommandError
 
 from sologit.core.repository import Repository
-from sologit.core.workpad import Workpad, Checkpoint
+from sologit.core.workpad import Workpad, Checkpoint, Snapshot, SnapshotNotFoundError
 from sologit.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -41,6 +41,16 @@ class WorkpadNotFoundError(GitEngineError):
 
 class CannotPromoteError(GitEngineError):
     """Workpad cannot be promoted."""
+    pass
+
+
+class RebaseConflictError(GitEngineError):
+    """A rebase operation resulted in conflicts."""
+    pass
+
+
+class SnapshotMismatchError(GitEngineError):
+    """Snapshot does not belong to the specified workpad."""
     pass
 
 
@@ -517,6 +527,146 @@ class GitEngine:
             logger.error(f"Failed to promote workpad: {e}")
             raise GitEngineError(f"Failed to promote workpad: {e}")
     
+    def rebase_workpad(self, pad_id: str, interactive: bool = False) -> None:
+        """
+        Rebase a workpad on top of the trunk branch.
+
+        Args:
+            pad_id: The ID of the workpad to rebase.
+            interactive: If True, performs an interactive rebase.
+
+        Raises:
+            WorkpadNotFoundError: If the workpad is not found.
+            RebaseConflictError: If the rebase operation fails due to conflicts.
+            GitEngineError: For other Git-related errors.
+        """
+        logger.info(f"Rebasing workpad {pad_id}")
+        workpad = self.workpad_db.get(pad_id)
+        if not workpad:
+            raise WorkpadNotFoundError(f"Workpad {pad_id} not found")
+
+        repository = self.repo_db[workpad.repo_id]
+        repo = Repo(repository.path)
+
+        try:
+            # Checkout the workpad branch
+            workpad_branch = repo.heads[workpad.branch_name]
+            workpad_branch.checkout()
+
+            # Start the rebase
+            trunk_branch = repository.trunk_branch
+            if interactive:
+                repo.git.rebase('-i', trunk_branch)
+            else:
+                repo.git.rebase(trunk_branch)
+
+            workpad.last_activity = datetime.now()
+            self._save_metadata()
+            logger.info(f"Workpad {pad_id} successfully rebased onto {trunk_branch}")
+
+        except GitCommandError as e:
+            # Check for rebase conflicts in the error message
+            if "Merge conflict" in str(e) or "could not apply" in str(e):
+                repo.git.rebase('--abort')
+                logger.error(f"Rebase conflict for workpad {pad_id}: {e}")
+                raise RebaseConflictError(f"Rebase failed for workpad {pad_id} due to conflicts. The rebase has been aborted.")
+            else:
+                logger.error(f"Failed to rebase workpad {pad_id}: {e}")
+                raise GitEngineError(f"An unexpected error occurred during rebase: {e}")
+
+    def create_snapshot(self, pad_id: str, message: str) -> str:
+        """
+        Create a snapshot of the workpad's current state, including uncommitted changes.
+
+        Args:
+            pad_id: The ID of the workpad.
+            message: A description for the snapshot.
+
+        Returns:
+            The ID of the created snapshot.
+        """
+        logger.info(f"Creating snapshot for workpad {pad_id}: {message}")
+        workpad = self.workpad_db.get(pad_id)
+        if not workpad:
+            raise WorkpadNotFoundError(f"Workpad {pad_id} not found")
+
+        repo = Repo(self.repo_db[workpad.repo_id].path)
+        self.switch_workpad(pad_id)
+
+        snapshot_id = f"snap_{uuid4().hex[:8]}"
+        stash_message = f"sologit-snapshot:{pad_id}:{snapshot_id}:{message}"
+
+        repo.git.stash('push', '-u', '-m', stash_message)
+
+        snapshot = Snapshot(id=snapshot_id, message=message)
+        workpad.snapshots[snapshot_id] = snapshot
+        self._save_metadata()
+
+        logger.info(f"Snapshot '{snapshot_id}' created for workpad {pad_id}")
+        return snapshot_id
+
+    def list_snapshots(self, pad_id: str) -> List[Snapshot]:
+        """List all snapshots for a workpad."""
+        workpad = self.workpad_db.get(pad_id)
+        if not workpad:
+            raise WorkpadNotFoundError(f"Workpad {pad_id} not found")
+        return list(workpad.snapshots.values())
+
+    def restore_snapshot(self, pad_id: str, snapshot_id: str) -> None:
+        """Restore a workpad to a previously created snapshot."""
+        logger.info(f"Restoring snapshot '{snapshot_id}' for workpad {pad_id}")
+        workpad = self.workpad_db.get(pad_id)
+        if not workpad:
+            raise WorkpadNotFoundError(f"Workpad {pad_id} not found")
+        if snapshot_id not in workpad.snapshots:
+            raise SnapshotNotFoundError(f"Snapshot '{snapshot_id}' not found in workpad {pad_id}")
+
+        repo = Repo(self.repo_db[workpad.repo_id].path)
+        self.switch_workpad(pad_id)
+
+        stashes = repo.git.stash('list').splitlines()
+        stash_index = -1
+        for i, line in enumerate(stashes):
+            if f"sologit-snapshot:{pad_id}:{snapshot_id}" in line:
+                stash_index = i
+                break
+
+        if stash_index == -1:
+            raise SnapshotNotFoundError(f"Stash for snapshot '{snapshot_id}' not found.")
+
+        # Reset the workpad to a clean state before applying the stash
+        repo.git.reset('--hard')
+        repo.git.clean('-fd')
+
+        repo.git.stash('pop', f'stash@{{{stash_index}}}')
+        logger.info(f"Snapshot '{snapshot_id}' restored for workpad {pad_id}")
+
+    def delete_snapshot(self, pad_id: str, snapshot_id: str) -> None:
+        """Delete a snapshot from a workpad."""
+        logger.info(f"Deleting snapshot '{snapshot_id}' from workpad {pad_id}")
+        workpad = self.workpad_db.get(pad_id)
+        if not workpad:
+            raise WorkpadNotFoundError(f"Workpad {pad_id} not found")
+        if snapshot_id not in workpad.snapshots:
+            raise SnapshotNotFoundError(f"Snapshot '{snapshot_id}' not found in workpad {pad_id}")
+
+        repo = Repo(self.repo_db[workpad.repo_id].path)
+        self.switch_workpad(pad_id)
+
+        stashes = repo.git.stash('list').splitlines()
+        stash_index = -1
+        for i, line in enumerate(stashes):
+            if f"sologit-snapshot:{pad_id}:{snapshot_id}" in line:
+                stash_index = i
+                break
+
+        if stash_index != -1:
+            repo.git.stash('drop', f'stash@{{{stash_index}}}')
+
+        del workpad.snapshots[snapshot_id]
+        self._save_metadata()
+        logger.info(f"Snapshot '{snapshot_id}' deleted from workpad {pad_id}")
+
     def revert_last_commit(self, repo_id: str) -> None:
         """
         Revert last commit on trunk (for Jenkins rollback).

--- a/sologit/engines/patch_engine.py
+++ b/sologit/engines/patch_engine.py
@@ -5,6 +5,7 @@ Patch Engine for Solo Git.
 Handles patch application, conflict detection, and validation.
 """
 
+import requests
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -28,6 +29,11 @@ class PatchConflictError(PatchEngineError):
 
 class PatchValidationError(PatchEngineError):
     """Patch validation failed."""
+    pass
+
+
+class GistError(PatchEngineError):
+    """Could not fetch or process a GitHub Gist."""
     pass
 
 
@@ -83,6 +89,44 @@ class PatchEngine:
         except GitEngineError as e:
             logger.error(f"Failed to apply patch: {e}")
             raise PatchEngineError(f"Failed to apply patch: {e}")
+
+    def apply_patch_from_gist(self, pad_id: str, gist_url: str, message: str = "") -> str:
+        """
+        Fetches a patch from a GitHub Gist URL and applies it to the workpad.
+
+        Args:
+            pad_id: The ID of the workpad.
+            gist_url: The URL of the GitHub Gist.
+            message: The commit message for the patch.
+
+        Returns:
+            The ID of the created checkpoint.
+
+        Raises:
+            GistError: If the Gist cannot be fetched or processed.
+        """
+        logger.info(f"Applying patch from Gist: {gist_url}")
+
+        if "github.com" not in gist_url:
+            raise GistError("Invalid Gist URL. Must be a github.com URL.")
+
+        try:
+            # Convert the Gist URL to the raw content URL
+            if not gist_url.endswith('/raw'):
+                gist_url += '/raw'
+
+            response = requests.get(gist_url, timeout=10)
+            response.raise_for_status()
+            patch_content = response.text
+
+            if not patch_content.strip():
+                raise GistError("Gist is empty.")
+
+            return self.apply_patch(pad_id, patch_content, message)
+
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Failed to fetch Gist: {e}")
+            raise GistError(f"Could not fetch Gist from URL: {gist_url}") from e
     
     def validate_patch(self, pad_id: str, patch: str) -> bool:
         """

--- a/tests/test_git_engine_rebase.py
+++ b/tests/test_git_engine_rebase.py
@@ -1,0 +1,90 @@
+
+import pytest
+from pathlib import Path
+import tempfile
+from zipfile import ZipFile
+from io import BytesIO
+from git import Repo
+
+from sologit.engines.git_engine import GitEngine, RebaseConflictError, WorkpadNotFoundError
+
+@pytest.fixture
+def git_engine():
+    """Create GitEngine with temporary data directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        engine = GitEngine(data_dir=Path(tmpdir))
+        yield engine
+
+def create_test_repo_with_divergence(engine: GitEngine):
+    """Creates a test repo with a workpad that has diverged from the trunk."""
+    zip_buffer = BytesIO()
+    with ZipFile(zip_buffer, 'w') as zf:
+        zf.writestr('file.txt', 'initial content')
+    zip_buffer.seek(0)
+
+    repo_id = engine.init_from_zip(zip_buffer.read(), name='Test Repo')
+    repo = engine.get_repo(repo_id)
+
+    pad_id = engine.create_workpad(repo_id, 'feature-branch')
+
+    repo_path = Path(repo.path)
+    git_repo = Repo(repo_path)
+
+    # Switch to trunk to make a commit
+    git_repo.heads.main.checkout()
+    (repo_path / 'file.txt').write_text('commit on trunk')
+    git_repo.index.add(['file.txt'])
+    git_repo.index.commit('Commit on trunk')
+
+    # Make a commit on the workpad
+    workpad = engine.get_workpad(pad_id)
+    git_repo.heads[workpad.branch_name].checkout()
+    (repo_path / 'another_file.txt').write_text('new file on workpad')
+    git_repo.index.add(['another_file.txt'])
+    git_repo.index.commit('Commit on workpad')
+
+    return repo_id, pad_id
+
+def test_rebase_workpad_success(git_engine: GitEngine):
+    """Test successful rebase of a workpad."""
+    repo_id, pad_id = create_test_repo_with_divergence(git_engine)
+
+    git_engine.rebase_workpad(pad_id)
+
+    repo = Repo(git_engine.get_repo(repo_id).path)
+    workpad = git_engine.get_workpad(pad_id)
+
+    trunk_commit = repo.heads['main'].commit
+    workpad_commit = repo.heads[workpad.branch_name].commit
+
+    assert trunk_commit in workpad_commit.parents
+
+def test_rebase_workpad_with_conflict(git_engine: GitEngine):
+    """Test that a rebase with conflicts raises a RebaseConflictError."""
+    zip_buffer = BytesIO()
+    with ZipFile(zip_buffer, 'w') as zf:
+        zf.writestr('file.txt', 'initial content')
+    zip_buffer.seek(0)
+
+    repo_id = git_engine.init_from_zip(zip_buffer.read(), name='Test Repo')
+    repo = git_engine.get_repo(repo_id)
+
+    pad_id = git_engine.create_workpad(repo_id, 'feature-branch')
+
+    repo_path = Path(repo.path)
+    git_repo = Repo(repo_path)
+
+    # Make conflicting commits
+    git_repo.heads.main.checkout()
+    (repo_path / 'file.txt').write_text('change on trunk')
+    git_repo.index.add(['file.txt'])
+    git_repo.index.commit('Change on trunk')
+
+    workpad = git_engine.get_workpad(pad_id)
+    git_repo.heads[workpad.branch_name].checkout()
+    (repo_path / 'file.txt').write_text('change on workpad')
+    git_repo.index.add(['file.txt'])
+    git_repo.index.commit('Change on workpad')
+
+    with pytest.raises(RebaseConflictError):
+        git_engine.rebase_workpad(pad_id)

--- a/tests/test_git_engine_snapshots.py
+++ b/tests/test_git_engine_snapshots.py
@@ -1,0 +1,80 @@
+
+import pytest
+from pathlib import Path
+import tempfile
+from zipfile import ZipFile
+from io import BytesIO
+from git import Repo
+
+from sologit.engines.git_engine import GitEngine, WorkpadNotFoundError, SnapshotNotFoundError
+
+@pytest.fixture
+def git_engine():
+    """Create GitEngine with temporary data directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        engine = GitEngine(data_dir=Path(tmpdir))
+        yield engine
+
+def create_test_repo(engine: GitEngine):
+    """Creates a test repo."""
+    zip_buffer = BytesIO()
+    with ZipFile(zip_buffer, 'w') as zf:
+        zf.writestr('file.txt', 'initial content')
+    zip_buffer.seek(0)
+
+    repo_id = engine.init_from_zip(zip_buffer.read(), name='Test Repo')
+    return repo_id
+
+def test_create_and_list_snapshots(git_engine: GitEngine):
+    """Test creating and listing snapshots."""
+    repo_id = create_test_repo(git_engine)
+    pad_id = git_engine.create_workpad(repo_id, 'feature-branch')
+
+    # Create a snapshot
+    snapshot_id = git_engine.create_snapshot(pad_id, "first snapshot")
+    assert snapshot_id.startswith("snap_")
+
+    # List snapshots
+    snapshots = git_engine.list_snapshots(pad_id)
+    assert len(snapshots) == 1
+    assert snapshots[0].id == snapshot_id
+    assert snapshots[0].message == "first snapshot"
+
+def test_restore_snapshot(git_engine: GitEngine):
+    """Test restoring a snapshot."""
+    repo_id = create_test_repo(git_engine)
+    pad_id = git_engine.create_workpad(repo_id, 'feature-branch')
+
+    repo_path = Path(git_engine.get_repo(repo_id).path)
+    file_path = repo_path / 'file.txt'
+
+    # Make a change and create a snapshot
+    file_path.write_text('state before snapshot')
+    snapshot_id = git_engine.create_snapshot(pad_id, "snapshot to restore")
+
+    # Make another change
+    file_path.write_text('state after snapshot')
+
+    # Restore the snapshot
+    git_engine.restore_snapshot(pad_id, snapshot_id)
+
+    # Check that the file content is restored
+    assert file_path.read_text() == 'state before snapshot'
+
+def test_delete_snapshot(git_engine: GitEngine):
+    """Test deleting a snapshot."""
+    repo_id = create_test_repo(git_engine)
+    pad_id = git_engine.create_workpad(repo_id, 'feature-branch')
+
+    snapshot_id = git_engine.create_snapshot(pad_id, "snapshot to delete")
+
+    # Delete the snapshot
+    git_engine.delete_snapshot(pad_id, snapshot_id)
+
+    # Check that the snapshot is gone
+    snapshots = git_engine.list_snapshots(pad_id)
+    assert len(snapshots) == 0
+
+    # Verify that trying to delete it again raises an error
+    with pytest.raises(SnapshotNotFoundError):
+        git_engine.delete_snapshot(pad_id, snapshot_id)

--- a/tests/test_patch_engine_gist.py
+++ b/tests/test_patch_engine_gist.py
@@ -1,0 +1,65 @@
+
+import pytest
+from unittest.mock import patch, MagicMock
+from sologit.engines.patch_engine import PatchEngine, GistError
+from sologit.engines.git_engine import GitEngine
+import tempfile
+from pathlib import Path
+from zipfile import ZipFile
+from io import BytesIO
+
+@pytest.fixture
+def git_engine():
+    """Create GitEngine with temporary data directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        engine = GitEngine(data_dir=Path(tmpdir))
+        yield engine
+
+@pytest.fixture
+def patch_engine(git_engine):
+    """Fixture for a PatchEngine with a mocked GitEngine."""
+    return PatchEngine(git_engine)
+
+@pytest.fixture
+def sample_zip():
+    """Create a sample zip file."""
+    buffer = BytesIO()
+    with ZipFile(buffer, 'w') as zf:
+        zf.writestr('file.txt', 'hello\\n')
+    buffer.seek(0)
+    return buffer.read()
+
+@patch('requests.get')
+def test_apply_patch_from_gist_success(mock_get, patch_engine, git_engine, sample_zip):
+    """Test successfully applying a patch from a Gist."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-hello\n+world\n"
+    mock_get.return_value = mock_response
+
+    repo_id = git_engine.init_from_zip(sample_zip, "Test Repo")
+    pad_id = git_engine.create_workpad(repo_id, "test-pad")
+
+    gist_url = "https://gist.github.com/user/12345"
+    checkpoint_id = patch_engine.apply_patch_from_gist(pad_id, gist_url, "test message")
+
+    mock_get.assert_called_once_with(gist_url + "/raw", timeout=10)
+    assert checkpoint_id is not None
+
+@patch('sologit.engines.patch_engine.requests.get')
+def test_apply_patch_from_gist_fetch_error(mock_get, patch_engine, git_engine, sample_zip):
+    """Test that a GistError is raised when the Gist fetch fails."""
+    mock_get.side_effect = Exception("Network error")
+
+    repo_id = git_engine.init_from_zip(sample_zip, "Test Repo")
+    pad_id = git_engine.create_workpad(repo_id, "test-pad")
+
+    with pytest.raises(GistError):
+        patch_engine.apply_patch_from_gist(pad_id, "https://gist.github.com/user/12345")
+
+def test_apply_patch_from_invalid_url(patch_engine, git_engine, sample_zip):
+    """Test that a GistError is raised for an invalid Gist URL."""
+    repo_id = git_engine.init_from_zip(sample_zip, "Test Repo")
+    pad_id = git_engine.create_workpad(repo_id, "test-pad")
+    with pytest.raises(GistError):
+        patch_engine.apply_patch_from_gist(pad_id, "https://example.com")


### PR DESCRIPTION
- Implements `evogitctl pad rebase` for interactive rebasing of workpads onto the trunk. This helps resolve diverged histories when the trunk has been updated.
- Adds a new `evogitctl pad snapshot` command group with subcommands to create, list, restore, and delete snapshots. Snapshots save the complete state of a workpad, including uncommitted changes, allowing for safe experimentation.
- Introduces `evogitctl pad patch --gist <URL>` to fetch and apply patches directly from GitHub Gist URLs, streamlining collaboration and patch management.
- Adds corresponding unit tests for the new functionalities.