### PR TITLE
Fix mypy workflow to use repository config

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -21,4 +21,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run mypy
-        run: mypy .
+        run: mypy --config-file pyproject.toml


### PR DESCRIPTION
## Summary
- update the type-check workflow to invoke mypy with the repository's configured settings so it no longer forces strict mode

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_6908d805dd54832ba7bed46a3bcb6dc2