### PR TITLE
Fix integration test workflow path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ with:
 python-version: '3.11'
 - run: pip install -e .[dev,test]
 - name: Run E2E tests
-run: pytest tests/test_workflow_e2e.py -v
+run: pytest tests/test_workflows.py -v
 Acceptance Criteria:
 - ✅ Tests run on Ubuntu, macOS, Windows
 - ✅ Tests run on Python 3.9, 3.10, 3.11


### PR DESCRIPTION
## Summary
- point the integration test job to run the existing workflow tests module

## Testing
- pytest tests/test_workflows.py -v

------
https://chatgpt.com/codex/tasks/task_e_6908d7ee14a4832b83b5c0b7e40bd7c8