### PR TITLE
Restore repository-wide mypy invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install mypy types-PyYAML types-requests
-      - run: mypy
+      - run: mypy .
 
   # Job 3: Linting
   lint:


### PR DESCRIPTION
## Summary
- ensure the CI type-check job runs mypy against the entire repository instead of relying on configuration defaults

## Testing
- no tests were run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_6908dab72234832bbf17eddc77269423